### PR TITLE
Disallow selection of already selected tokens

### DIFF
--- a/src/problem2/src/app/page.tsx
+++ b/src/problem2/src/app/page.tsx
@@ -49,9 +49,15 @@ export default function Home() {
 
         let min: number = 0;
         let max: number = filteredData.length;
+        let first: number = getRandom(min, max);
+        let second: number;
 
-        setFromToken(filteredData[getRandom(min, max)]);
-        setToToken(filteredData[getRandom(min, max)]);
+        do {
+          second = getRandom(min, max)
+        } while (first === second);
+
+        setFromToken(filteredData[first]);
+        setToToken(filteredData[second]);
       })
       .catch((error) => {
         console.log("Error in fetching data: ", error);

--- a/src/problem2/src/components/token-row.tsx
+++ b/src/problem2/src/components/token-row.tsx
@@ -45,6 +45,7 @@ export default function TokenRow({
       <TokenSelector
         data={fetchedData}
         selectedToken={thisToken}
+        otherToken={otherToken}
         setSelectedToken={setThisToken}
       />
     </div>

--- a/src/problem2/src/components/token-selector.tsx
+++ b/src/problem2/src/components/token-selector.tsx
@@ -10,6 +10,7 @@ import { AppBar, DialogContent, Toolbar } from "@mui/material";
 type TokenSelectorDialogProps = {
   isOpen: boolean;
   selectedToken: Token | null;
+  otherToken: Token | null;
   handleClose: (value: Token | null) => void;
   tokens: Token[];
 };
@@ -17,12 +18,14 @@ type TokenSelectorDialogProps = {
 type TokenSelectorProps = {
   data: Token[];
   selectedToken: Token | null;
+  otherToken: Token | null
   setSelectedToken: React.Dispatch<React.SetStateAction<Token | null>>;
 };
 
 function TokenSelectorDialog({
   isOpen,
   selectedToken,
+  otherToken,
   handleClose,
   tokens,
 }: TokenSelectorDialogProps) {
@@ -91,6 +94,7 @@ function TokenSelectorDialog({
                 }}
                 className="w-full flex flex-col px-2 h-fit rounded-lg"
                 variant="outlined"
+                disabled = {token.currency === selectedToken!.currency || token.currency === otherToken!.currency}
                 onClick={() => {
                   handleClose(token);
                 }}
@@ -116,6 +120,7 @@ function TokenSelectorDialog({
 export default function TokenSelector({
   data,
   selectedToken,
+  otherToken,
   setSelectedToken,
 }: TokenSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -154,6 +159,7 @@ export default function TokenSelector({
       <TokenSelectorDialog
         tokens={data}
         selectedToken={selectedToken}
+        otherToken={otherToken}
         isOpen={isOpen}
         handleClose={handleClose}
       />


### PR DESCRIPTION
- This PR is to prevent swapping between the same tokens
- One approach is to filter out the selected tokens in the displayed list of tokens in the token selector dialog 
- Another approach that is settled is to keep those tokens in the displayed list but dont allow users to select them (through the disabled attribute of the MUI button element).
![image](https://github.com/ph-nathan/switcheo-code-challenge/assets/99804772/55c01679-b752-40b6-86b2-68ded8059332)